### PR TITLE
Added reference to petl python package

### DIFF
--- a/on_the_web/index.html
+++ b/on_the_web/index.html
@@ -61,6 +61,8 @@
 
 <p><a href="https://neo4j.com/developer">Neo4j</a> the open-source graph database supports JSONL export and import via its standard library procedures <a hef="https://neo4j.com/labs/apoc/4.1/export/json/#export-database-json"><code>apoc.export/import.json</code></a> to allow stream processing of nodes and relationships.</p>
 
+<p><a href="https://github.com/petl-developers/petl">petl</a> is a general purpose Python package for extracting, transforming and loading tables of data. It allows importing and exporting documents/records between many <a href="https://petl.readthedocs.io/en/stable/io.html#databases">databases</a> and file formats, including <a href="https://petl.readthedocs.io/en/stable/io.html#json-files">JSON lines</a>, in local and <a href="https://petl.readthedocs.io/en/stable/io.html#remote-i-o-helper-classes">remote</a> filesystems and clouds.</p>
+
         </section>
         <footer>
           <a href="https://github.com/wardi/jsonlines/issues">Report a bug or make a suggestion</a> &bull;


### PR DESCRIPTION
[petl](https://github.com/petl-developers/petl) is a general purpose Python package for extracting, transforming and loading tables of data.

It allows importing and exporting documents/records between many databases and file formats, [including](https://petl.readthedocs.io/en/stable/io.html#json-files) JSON lines, in local and remote filesystems and clouds.