### PR TITLE
Add Mattermost link

### DIFF
--- a/on_the_web/index.html
+++ b/on_the_web/index.html
@@ -74,7 +74,9 @@
 
 <p><a href="https://github.com/simonfrey/jsonl">Golang JSONL library</a></p>
 
-<p><a href="https://miller.readthedocs.io/en/latest/file-formats/#json-lines">Miller</a> supports JSON Lines format as input.</p>          
+<p><a href="https://miller.readthedocs.io/en/latest/file-formats/#json-lines">Miller</a> supports JSON Lines format as input.</p>
+
+<p><a href="https://mattermost.com/">Mattermost</a> is an open-source, self-hostable online chat service. It uses JSON Lines as the format for <a href="https://clickhouse.yandex/reference_en.html#JSONEachRow">bulk data migration</a> on self-hosted instances.</p>
         </section>
         <footer>
           <a href="https://github.com/wardi/jsonlines/issues">Report a bug or make a suggestion</a> &bull;


### PR DESCRIPTION
Added Mattermost as an example in the On the web section. Issue #79 can be closed.
