### PR TITLE
Add Go's standard library

### DIFF
--- a/on_the_web/index.html
+++ b/on_the_web/index.html
@@ -71,6 +71,8 @@
 <p><a href="https://shopify.dev/api/usage/bulk-operations/queries">Shopify GraphQL Bulk Operations API</a>, designed for very large data exports from Shopify stores, returns results in the form of a JSONL file.</p>
 
 <p><a href="https://www.htmlvalidator.com/">CSS HTML Validator for Windows v22.0211+</a> now supports JSON Lines syntax checking.</p>
+          
+<p><a href="https://pkg.go.dev/encoding/json#NewEncoder">Go Standard library's json.Encoder</a> will produce JSON lines by default. The decoder parses Concatenated JSON, which is compatible with, though less strict than, JSON lines</p>
 
 <p><a href="https://github.com/simonfrey/jsonl">Golang JSONL library</a></p>
 


### PR DESCRIPTION
Suggest the Go standard library over a 3rd party library that wraps the standard library