### PR TITLE
Add serde-jsonlines

### DIFF
--- a/on_the_web/index.html
+++ b/on_the_web/index.html
@@ -79,6 +79,8 @@
 <p><a href="https://miller.readthedocs.io/en/latest/file-formats/#json-lines">Miller</a> supports JSON Lines format as input.</p>
 
 <p><a href="https://docs.mattermost.com/onboard/bulk-loading-data.html">Mattermost</a> is a collaboration tool and uses the JSON Lines format for bulk data import.</p>
+
+<p><a href="https://github.com/jwodder/serde-jsonlines">serde-jsonlines</a> is a Rust library for reading &amp; writing JSON Lines documents.</p>
         </section>
         <footer>
           <a href="https://github.com/wardi/jsonlines/issues">Report a bug or make a suggestion</a> &bull;


### PR DESCRIPTION
This PR adds [serde-jsonlines](https://github.com/jwodder/serde-jsonlines) to the "On the web" section.

Disclaimer: I am the author of serde-jsonlines, but it's my most popular Rust library (and seemingly the only Rust library dedicated to JSON Lines aside from one undocumented one).