### PR TITLE
Provide an example of JSONL files with one self-describing object per row

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -34,6 +34,19 @@
 
         <section id="main_content">
           <h3>
+<a name="self-describing" class="anchor" href="#self-describing"><span class="octicon octicon-link"></span></a>Self-describing data</h3>
+
+<div class="highlight"><pre><span class="p">{</span><span class="nt">"name"</span><span class="p">:</span> <span class="s2">"Gilbert"</span><span class="p">,</span> <span class="nt">"session"</span><span class="p">:</span> <span class="s2">"2013"</span><span class="p">,</span> <span class="nt">"score"</span><span class="p">:</span> <span class="mi">24</span><span class="p">,</span> <span class="nt">"completed"</span><span class="p">:</span> <span class="kc">true</span><span class="p">}</span>
+<span class="p">{</span><span class="nt">"name"</span><span class="p">:</span> <span class="s2">"Alexa"</span><span class="p">,</span> <span class="nt">"session"</span><span class="p">:</span> <span class="s2">"2013"</span><span class="p">,</span> <span class="nt">"score"</span><span class="p">:</span> <span class="mi">29</span><span class="p">,</span> <span class="nt">"completed"</span><span class="p">:</span> <span class="kc">true</span><span class="p">}</span>
+<span class="p">{</span><span class="nt">"name"</span><span class="p">:</span> <span class="s2">"May"</span><span class="p">,</span> <span class="nt">"session"</span><span class="p">:</span> <span class="s2">"2012B"</span><span class="p">,</span> <span class="nt">"score"</span><span class="p">:</span> <span class="mi">14</span><span class="p">,</span> <span class="nt">"completed"</span><span class="p">:</span> <span class="kc">false</span><span class="p">}</span>
+<span class="p">{</span><span class="nt">"name"</span><span class="p">:</span> <span class="s2">"Deloise"</span><span class="p">,</span> <span class="nt">"session"</span><span class="p">:</span> <span class="s2">"2012A"</span><span class="p">,</span> <span class="nt">"score"</span><span class="p">:</span> <span class="mi">19</span><span class="p">,</span> <span class="nt">"completed"</span><span class="p">:</span> <span class="kc">true</span><span class="p">}</span> 
+</pre></div>
+
+          <p>JSON Lines enables applications to read objects line-by-line, with each line fully describing a JSON object.</p>
+
+          <p>This allows applications to append objects to files, split files on newline boundaries for parallel loading, and eliminates any ambiguity if fields are omitted or re-ordered.</p>
+
+          <h3>
 <a name="better-than-csv" class="anchor" href="#better-than-csv"><span class="octicon octicon-link"></span></a>Better than CSV</h3>
 
 <div class="highlight"><pre><span class="p">[</span><span class="s2">"Name"</span><span class="p">,</span> <span class="s2">"Session"</span><span class="p">,</span> <span class="s2">"Score"</span><span class="p">,</span> <span class="s2">"Completed"</span><span class="p">]</span>
@@ -45,7 +58,7 @@
 
           <p>CSV seems so easy that many programmers have written code to generate it themselves, and almost every implementation is different. Handling broken CSV files is a common and frustrating task. CSV has no standard encoding, no standard column separator and multiple character escaping standards. String is the only type supported for cell values, so some programs attempt to guess the correct types.</p>
 
-          <p>JSON Lines handles tabular data cleanly and without ambiguity. Cells may use the standard JSON types.</p>
+          <p>This tabular format does not have the benefit of a <a href="#self-describing">self-describing</a> object per line, but it handles tabular data cleanly and without ambiguity. Cells may use the standard JSON types.</p>
 
           <p>The biggest missing piece is an import/export filter for popular spreadsheet programs so that non-programmers can use this format.</p>
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -58,7 +58,7 @@
 
           <p>CSV seems so easy that many programmers have written code to generate it themselves, and almost every implementation is different. Handling broken CSV files is a common and frustrating task. CSV has no standard encoding, no standard column separator and multiple character escaping standards. String is the only type supported for cell values, so some programs attempt to guess the correct types.</p>
 
-          <p>This tabular format does not have the benefit of a <a href="#self-describing">self-describing</a> object per line, but it handles tabular data cleanly and without ambiguity. Cells may use the standard JSON types.</p>
+          <p>The example above is a possible tabular representation of the <a href="#self-describing">self-describing</a> objects in the first example.  This representation does not allow applications to split files on newline boundaries, but it handles tabular data cleanly and without ambiguity. Cells may use the standard JSON types.</p>
 
           <p>The biggest missing piece is an import/export filter for popular spreadsheet programs so that non-programmers can use this format.</p>
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -34,19 +34,6 @@
 
         <section id="main_content">
           <h3>
-<a name="self-describing" class="anchor" href="#self-describing"><span class="octicon octicon-link"></span></a>Self-describing data</h3>
-
-<div class="highlight"><pre><span class="p">{</span><span class="nt">"name"</span><span class="p">:</span> <span class="s2">"Gilbert"</span><span class="p">,</span> <span class="nt">"session"</span><span class="p">:</span> <span class="s2">"2013"</span><span class="p">,</span> <span class="nt">"score"</span><span class="p">:</span> <span class="mi">24</span><span class="p">,</span> <span class="nt">"completed"</span><span class="p">:</span> <span class="kc">true</span><span class="p">}</span>
-<span class="p">{</span><span class="nt">"name"</span><span class="p">:</span> <span class="s2">"Alexa"</span><span class="p">,</span> <span class="nt">"session"</span><span class="p">:</span> <span class="s2">"2013"</span><span class="p">,</span> <span class="nt">"score"</span><span class="p">:</span> <span class="mi">29</span><span class="p">,</span> <span class="nt">"completed"</span><span class="p">:</span> <span class="kc">true</span><span class="p">}</span>
-<span class="p">{</span><span class="nt">"name"</span><span class="p">:</span> <span class="s2">"May"</span><span class="p">,</span> <span class="nt">"session"</span><span class="p">:</span> <span class="s2">"2012B"</span><span class="p">,</span> <span class="nt">"score"</span><span class="p">:</span> <span class="mi">14</span><span class="p">,</span> <span class="nt">"completed"</span><span class="p">:</span> <span class="kc">false</span><span class="p">}</span>
-<span class="p">{</span><span class="nt">"name"</span><span class="p">:</span> <span class="s2">"Deloise"</span><span class="p">,</span> <span class="nt">"session"</span><span class="p">:</span> <span class="s2">"2012A"</span><span class="p">,</span> <span class="nt">"score"</span><span class="p">:</span> <span class="mi">19</span><span class="p">,</span> <span class="nt">"completed"</span><span class="p">:</span> <span class="kc">true</span><span class="p">}</span> 
-</pre></div>
-
-          <p>JSON Lines enables applications to read objects line-by-line, with each line fully describing a JSON object.</p>
-
-          <p>This allows applications to append objects to files, split files on newline boundaries for parallel loading, and eliminates any ambiguity if fields are omitted or re-ordered.</p>
-
-          <h3>
 <a name="better-than-csv" class="anchor" href="#better-than-csv"><span class="octicon octicon-link"></span></a>Better than CSV</h3>
 
 <div class="highlight"><pre><span class="p">[</span><span class="s2">"Name"</span><span class="p">,</span> <span class="s2">"Session"</span><span class="p">,</span> <span class="s2">"Score"</span><span class="p">,</span> <span class="s2">"Completed"</span><span class="p">]</span>
@@ -58,9 +45,20 @@
 
           <p>CSV seems so easy that many programmers have written code to generate it themselves, and almost every implementation is different. Handling broken CSV files is a common and frustrating task. CSV has no standard encoding, no standard column separator and multiple character escaping standards. String is the only type supported for cell values, so some programs attempt to guess the correct types.</p>
 
-          <p>The example above is a possible tabular representation of the <a href="#self-describing">self-describing</a> objects in the first example.  This representation does not allow applications to split files on newline boundaries, but it handles tabular data cleanly and without ambiguity. Cells may use the standard JSON types.</p>
+          <p>JSON Lines handles tabular data cleanly and without ambiguity. Cells may use the standard JSON types.</p>
 
           <p>The biggest missing piece is an import/export filter for popular spreadsheet programs so that non-programmers can use this format.</p>
+
+          <h3>
+<a name="self-describing" class="anchor" href="#self-describing"><span class="octicon octicon-link"></span></a>Self-describing data</h3>
+
+<div class="highlight"><pre><span class="p">{</span><span class="nt">"name"</span><span class="p">:</span> <span class="s2">"Gilbert"</span><span class="p">,</span> <span class="nt">"session"</span><span class="p">:</span> <span class="s2">"2013"</span><span class="p">,</span> <span class="nt">"score"</span><span class="p">:</span> <span class="mi">24</span><span class="p">,</span> <span class="nt">"completed"</span><span class="p">:</span> <span class="kc">true</span><span class="p">}</span>
+<span class="p">{</span><span class="nt">"name"</span><span class="p">:</span> <span class="s2">"Alexa"</span><span class="p">,</span> <span class="nt">"session"</span><span class="p">:</span> <span class="s2">"2013"</span><span class="p">,</span> <span class="nt">"score"</span><span class="p">:</span> <span class="mi">29</span><span class="p">,</span> <span class="nt">"completed"</span><span class="p">:</span> <span class="kc">true</span><span class="p">}</span>
+<span class="p">{</span><span class="nt">"name"</span><span class="p">:</span> <span class="s2">"May"</span><span class="p">,</span> <span class="nt">"session"</span><span class="p">:</span> <span class="s2">"2012B"</span><span class="p">,</span> <span class="nt">"score"</span><span class="p">:</span> <span class="mi">14</span><span class="p">,</span> <span class="nt">"completed"</span><span class="p">:</span> <span class="kc">false</span><span class="p">}</span>
+<span class="p">{</span><span class="nt">"name"</span><span class="p">:</span> <span class="s2">"Deloise"</span><span class="p">,</span> <span class="nt">"session"</span><span class="p">:</span> <span class="s2">"2012A"</span><span class="p">,</span> <span class="nt">"score"</span><span class="p">:</span> <span class="mi">19</span><span class="p">,</span> <span class="nt">"completed"</span><span class="p">:</span> <span class="kc">true</span><span class="p">}</span> 
+</pre></div>
+
+          <p>JSON Lines enables applications to read objects line-by-line, with each line fully describing a JSON object.  The example above contains the same data as the <a href="#better-than-csv">tabular example</a> above, but allows applications to split files on newline boundaries for parallel loading, and eliminates any ambiguity if fields are omitted or re-ordered.</p>
 
           <h3>
 <a name="easy-nested-data" class="anchor" href="#easy-nested-data"><span class="octicon octicon-link"></span></a>Easy Nested Data</h3>


### PR DESCRIPTION
As described on #93 most implementations of JSONL do not grok the tabular format described on `/examples` - this provides a short description of the benefits of self-describing data.