### PR TITLE
Mention Virtual JSON Viewer browser extension

### DIFF
--- a/on_the_web/index.html
+++ b/on_the_web/index.html
@@ -84,6 +84,8 @@
 
 <p><a href="https://github.com/jwodder/serde-jsonlines">serde-jsonlines</a> is a Rust library for reading &amp; writing JSON Lines documents.</p>
 
+<p><a href="https://github.com/paolosimone/virtual-json-viewer">Virtual JSON Viewer</a> is a browser extension for navigating large JSON content. It natively supports JSON Lines format as input.</p>
+
         </section>
         <footer>
           <a href="https://github.com/wardi/jsonlines/issues">Report a bug or make a suggestion</a> &bull;


### PR DESCRIPTION
👋 I'm the maintainer of [Virtual JSON Viewer](https://github.com/paolosimone/virtual-json-viewer): a Chromium/Firefox extension for navigating possibly large JSON content. 

The latest [v1.2.0](https://github.com/paolosimone/virtual-json-viewer/releases/tag/v1.2.0) release introduced support for JSON Lines, both as input (e.g. from file or from `application/json-seq` content-type) and as result of integrated [jq](https://jqlang.github.io/jq/) functionality.

It's not a mainstream JSON Viewer, but it could nevertheless worth to mention in the "On the web" section.