### PR TITLE
Add precision about empty lines

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
           </h3>
           <p>
             The most common values will be objects or arrays, but any JSON value is permitted.
-            As reminded in issue <a href="https://github.com/wardi/jsonlines/issues/100#issuecomment-2897805072">#100</a>, empty lines are not valid JSON.
+            e.g. <code>null</code> is a valid value but a blank line is not.
           </p>
           <p>
             See <a href="https://json.org/">json.org</a> for a definition of JSON values.

--- a/index.html
+++ b/index.html
@@ -64,6 +64,7 @@
           </h3>
           <p>
             The most common values will be objects or arrays, but any JSON value is permitted.
+            As reminded in issue <a href="https://github.com/wardi/jsonlines/issues/100#issuecomment-2897805072">#100</a>, empty lines are not valid JSON.
           </p>
           <p>
             See <a href="https://json.org/">json.org</a> for a definition of JSON values.
@@ -82,7 +83,7 @@
           </p>
           <h3>
             <a name="conventions" class="anchor" href="#conventions" id="conventions"></a>
-            4. Suggested Conventions
+            Conventions
           </h3>
           <p>
             JSON Lines files may be saved with the file extension <code>.jsonl</code>.


### PR DESCRIPTION
- Reference the issue and remind that empty lines are not valid JSON
- Remove the `4.` on the conventions, because it was weird with the `has three requirements:` from above.
- Also remove "Suggested", as there are here for a long time already.